### PR TITLE
Set correct permission for merged config

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	
+	err = os.Chmod(filepath.Join(kubeDir, "config"), 0600)
+    	if err != nil {
+        	log.Fatal(err)
+    	}
 
 	_, err = file.Write(kubectlOut)
 


### PR DESCRIPTION
Set 0600 file permission to avoid warnings on helm and kubectl commands: 
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/tacio/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/tacio/.kube/config